### PR TITLE
chore: update repository template to af2114f8

### DIFF
--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -22,5 +22,5 @@ jobs:
       - uses: ory/closed-reference-notifier@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issueLabels: upstream
+          issueLabels: upstream,good first issue,help wanted
           issueLimit: ${{ github.event.inputs.issueLimit || '5' }}


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/af2114f86f06ec1328d210c3034b405641a74a27.