### PR TITLE
fix: add consent banner for cookies and google analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -179,5 +179,28 @@ module.exports = {
       },
     },
     `gatsby-plugin-force-trailing-slashes`,
+    {
+      resolve: `gatsby-plugin-gdpr-cookies`,
+      options: {
+        googleAnalytics: {
+          trackingId: 'UA-71865250-1',
+          cookieName: 'gdpr_cookie_analytics',
+          anonymize: true,
+          allowAdFeatures: false
+        },
+        googleTagManager: {
+          trackingId: 'GTM-MJD22FZ',
+          cookieName: 'gdpr_cookie_analytics'
+        },
+
+        // facebookPixel: {
+        //   pixelId: 'YOUR_FACEBOOK_PIXEL_ID', // leave empty if you want to disable the tracker
+        //   cookieName: 'gatsby-gdpr-facebook-pixel', // default
+        // },
+        // defines the environments where the tracking should be available  - default is ["production"]
+
+        environments: ['production', 'development']
+      },
+    },
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7389,6 +7389,16 @@
         "@types/node": ">= 8"
       }
     },
+    "@palmabit/react-cookie-law": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@palmabit/react-cookie-law/-/react-cookie-law-0.4.0.tgz",
+      "integrity": "sha512-RWf51j3eHWXbKrvb7RtVujcyYTCRUL0QAypuIVVYqgQPEHBNWfD+jkLpayzGi3iHHUP4HqqkdgRHaV6okSIwpg==",
+      "requires": {
+        "prop-types": "^15.6.2",
+        "react": "^16",
+        "react-cookie": "^3.0.4"
+      }
+    },
     "@pieh/friendly-errors-webpack-plugin": {
       "version": "1.7.0-chalk-2",
       "resolved": "https://registry.npmjs.org/@pieh/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0-chalk-2.tgz",
@@ -7877,6 +7887,11 @@
       "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-2.1.1.tgz",
       "integrity": "sha1-zR6FU2M60xhcPy8jns/10mQ+krY="
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/css-modules-loader-core": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz",
@@ -7970,6 +7985,15 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
       "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA=="
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "@types/http-cache-semantics": {
       "version": "4.0.0",
@@ -8093,6 +8117,11 @@
       "version": "0.0.25",
       "resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-0.0.25.tgz",
       "integrity": "sha512-ShHzHkYD+Ldw3eyttptCpUhF1/mkInWwasQkCNXZHOsJMJ/UMa8wXrxSrTJaVk0r4pLK/VnESVM0wFsfQzNEKQ=="
+    },
+    "@types/object-assign": {
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
+      "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -16749,6 +16778,33 @@
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
+    "gatsby-plugin-gdpr-cookies": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-gdpr-cookies/-/gatsby-plugin-gdpr-cookies-1.0.10.tgz",
+      "integrity": "sha512-iDZGe++Arw6gl57B9vqXz6Vk2sBJvgKQSNU0uD7cXhqhWvht8iOdhevhEZZdAdp0QtaMgOowTq6PMqHoyN4W0A==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "common-tags": "^1.8.0",
+        "minimist": "^1.2.5",
+        "react-ga": "^3.1.2",
+        "universal-cookie": "^4.0.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },
@@ -28367,6 +28423,34 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "react-cookie": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-3.1.2.tgz",
+      "integrity": "sha512-kHBDW7dLiXfvR+lw2ZeH9fMjEM0gf1IwxDXOyXQrf22X5+Ifluyz22HCVFzq1va6FSEHk6hrBbH6oeNLTD2vIQ==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^3.1.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "universal-cookie": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-3.1.0.tgz",
+          "integrity": "sha512-sP6WuFgqIUro7ikgI2ndrsw9Ro+YvVBe5O9cQfWnjTicpLaSMUEUUDjQF8m8utzWF2ONl7tRkcZd7v4n6NnzjQ==",
+          "requires": {
+            "@types/cookie": "^0.3.1",
+            "@types/object-assign": "^4.0.30",
+            "cookie": "^0.3.1",
+            "object-assign": "^4.1.0"
+          }
+        }
+      }
+    },
     "react-countup": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-4.3.3.tgz",
@@ -28644,6 +28728,11 @@
         "use-callback-ref": "^1.2.1",
         "use-sidecar": "^1.0.1"
       }
+    },
+    "react-ga": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.2.0.tgz",
+      "integrity": "sha512-YHHG5QIzRdDToB9ST1/BrGQhLZPzkrNjoeTu3SZLgwdqzeA9F2XOStuOGXAp1ak/SAo9pyR1Uo/hY0C5wZwfqA=="
     },
     "react-helmet": {
       "version": "5.2.1",
@@ -32898,6 +32987,15 @@
       "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
       "requires": {
         "unist-util-is": "^3.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {
+    "@palmabit/react-cookie-law": "^0.4.0",
     "@raae/gatsby-remark-oembed": "~0.1.1",
     "@types/classnames": "~2.2.10",
     "@types/csv-parse": "~1.2.2",
@@ -26,6 +27,7 @@
     "gatsby": "^2.24.81",
     "gatsby-image": "^2.4.12",
     "gatsby-plugin-force-trailing-slashes": "~1.0.4",
+    "gatsby-plugin-gdpr-cookies": "^1.0.10",
     "gatsby-plugin-manifest": "^2.4.17",
     "gatsby-plugin-offline": "^3.2.16",
     "gatsby-plugin-postcss": "^2.3.9",

--- a/src/components/adopters.module.css.d.ts
+++ b/src/components/adopters.module.css.d.ts
@@ -1,8 +1,7 @@
 declare const styles: {
-  readonly "adopters": string;
-  readonly "list": string;
-  readonly "logos": string;
-  readonly "logosInner": string;
-};
-export = styles;
-
+  readonly adopters: string
+  readonly list: string
+  readonly logos: string
+  readonly logosInner: string
+}
+export = styles

--- a/src/components/adopters.tsx
+++ b/src/components/adopters.tsx
@@ -75,7 +75,7 @@ const adopters = [
     title: 'Data Detect',
     image: datadetect,
     url: 'https://unifiedglobalarchiving.com/data-detect/',
-  }
+  },
 ]
 
 interface PropTypes {
@@ -90,10 +90,10 @@ const Adopters = ({ onlyFeatured }: PropTypes) => (
           <div className={styles.logos}>
             <div className={styles.logosInner}>
               {adopters
-                .filter(({ featured }) => onlyFeatured ? featured : true)
+                .filter(({ featured }) => (onlyFeatured ? featured : true))
                 .map(({ title, image, url }) => (
                   <a href={url} key={title}>
-                    <img src={image} alt={title}/>
+                    <img src={image} alt={title} />
                   </a>
                 ))}
             </div>

--- a/src/components/announcement.module.css.d.ts
+++ b/src/components/announcement.module.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "announcement": string;
-};
-export = styles;
-
+  readonly announcement: string
+}
+export = styles

--- a/src/components/blog-hero.module.css.d.ts
+++ b/src/components/blog-hero.module.css.d.ts
@@ -1,9 +1,8 @@
 declare const styles: {
-  readonly "title": string;
-  readonly "meta": string;
-  readonly "author": string;
-  readonly "subtitle": string;
-  readonly "teaser": string;
-};
-export = styles;
-
+  readonly title: string
+  readonly meta: string
+  readonly author: string
+  readonly subtitle: string
+  readonly teaser: string
+}
+export = styles

--- a/src/components/blog-section.module.css.d.ts
+++ b/src/components/blog-section.module.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "section": string;
-};
-export = styles;
-
+  readonly section: string
+}
+export = styles

--- a/src/components/blog-summary-section.module.css
+++ b/src/components/blog-summary-section.module.css
@@ -1,12 +1,16 @@
 @import '../styles/properties.css';
 
 .blog-summary {
-  background: linear-gradient(to bottom, var(--colors-themed-default) 96px, var(--colors-base-light) 96px);
+  background: linear-gradient(
+    to bottom,
+    var(--colors-themed-default) 96px,
+    var(--colors-base-light) 96px
+  );
 
   & h4 {
     height: auto;
     margin-bottom: 16px;
-    color: var(--colors-themed-default)
+    color: var(--colors-themed-default);
   }
 
   & :global a:any-link {
@@ -37,7 +41,6 @@
 }
 
 @media (--sm-viewport) {
-
   .blog-summary {
     & h4 {
       height: auto;
@@ -54,7 +57,6 @@
 }
 
 @media (--md-viewport) {
-
   .blog-summary {
     & h4 {
       height: auto;
@@ -69,4 +71,3 @@
     width: 100%;
   }
 }
-

--- a/src/components/blog-summary-section.module.css.d.ts
+++ b/src/components/blog-summary-section.module.css.d.ts
@@ -1,7 +1,6 @@
 declare const styles: {
-  readonly "blogSummary": string;
-  readonly "blogRow": string;
-  readonly "blogBox": string;
-};
-export = styles;
-
+  readonly blogSummary: string
+  readonly blogRow: string
+  readonly blogBox: string
+}
+export = styles

--- a/src/components/blog-summary-section.tsx
+++ b/src/components/blog-summary-section.tsx
@@ -19,24 +19,30 @@ type Edge = {
 
 const BlogSummarySection = () => {
   const data = useStaticQuery(graphql`
-query {
-  allMarkdownRemark(filter: {fileAbsolutePath: {regex: "/blog/"}, frontmatter: {published: {eq: true}}}, sort: {fields: [frontmatter___publishedAt], order: DESC}, limit: 3) {
-    edges {
-      node {
-        id
-        excerpt(pruneLength: 250)
-        frontmatter {
-          path
-          teaser
-          category
-          title
+    query {
+      allMarkdownRemark(
+        filter: {
+          fileAbsolutePath: { regex: "/blog/" }
+          frontmatter: { published: { eq: true } }
+        }
+        sort: { fields: [frontmatter___publishedAt], order: DESC }
+        limit: 3
+      ) {
+        edges {
+          node {
+            id
+            excerpt(pruneLength: 250)
+            frontmatter {
+              path
+              teaser
+              category
+              title
+            }
+          }
         }
       }
     }
-  }
-}
-`)
-
+  `)
 
   const posts = (data.allMarkdownRemark.edges as Edge[]).map(({ node }) => node)
   return (
@@ -44,17 +50,25 @@ query {
       <div className="container-fluid">
         <div className={cn('row middle-lg')}>
           <div
-            className={cn('col-lg-offset-1 col-lg-10 col-md-offset-1 col-md-10 col-sm-offset-1 col-sm-10', styles.blogRow)}>
-            {posts.map(({ id, excerpt, frontmatter: { title, overline, teaser, path } }) => (
-              <Link key={id} to={path} className={cn( styles.blogBox)}>
-                <h4 className={cn('col-lg-offset-1 col-lg-10')}>
-                  {title}
-                </h4>
-                <p className={cn('col-lg-offset-1 col-lg-10', 'secondary')}>
-                  {teaser}
-                </p>
-              </Link>
-            ))}
+            className={cn(
+              'col-lg-offset-1 col-lg-10 col-md-offset-1 col-md-10 col-sm-offset-1 col-sm-10',
+              styles.blogRow
+            )}
+          >
+            {posts.map(
+              ({
+                id,
+                excerpt,
+                frontmatter: { title, overline, teaser, path },
+              }) => (
+                <Link key={id} to={path} className={cn(styles.blogBox)}>
+                  <h4 className={cn('col-lg-offset-1 col-lg-10')}>{title}</h4>
+                  <p className={cn('col-lg-offset-1 col-lg-10', 'secondary')}>
+                    {teaser}
+                  </p>
+                </Link>
+              )
+            )}
           </div>
         </div>
       </div>

--- a/src/components/codebox.module.css.d.ts
+++ b/src/components/codebox.module.css.d.ts
@@ -1,14 +1,13 @@
 declare const styles: {
-  readonly "box": string;
-  readonly "editorHeader": string;
-  readonly "tabs": string;
-  readonly "tab": string;
-  readonly "selected": string;
-  readonly "windowActions": string;
-  readonly "windowAction": string;
-  readonly "primary": string;
-  readonly "content": string;
-  readonly "active": string;
-};
-export = styles;
-
+  readonly box: string
+  readonly editorHeader: string
+  readonly tabs: string
+  readonly tab: string
+  readonly selected: string
+  readonly windowActions: string
+  readonly windowAction: string
+  readonly primary: string
+  readonly content: string
+  readonly active: string
+}
+export = styles

--- a/src/components/collaborator.module.css.d.ts
+++ b/src/components/collaborator.module.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "collaborator": string;
-};
-export = styles;
-
+  readonly collaborator: string
+}
+export = styles

--- a/src/components/compressed-hero.module.css.d.ts
+++ b/src/components/compressed-hero.module.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "compressedHero": string;
-};
-export = styles;
-
+  readonly compressedHero: string
+}
+export = styles

--- a/src/components/compressed-hero.tsx
+++ b/src/components/compressed-hero.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode } from 'react'
 import cn from 'classnames'
 import * as styles from './compressed-hero.module.css'
 
-
 interface CallToAction {
   title: string
   href: string
@@ -18,13 +17,18 @@ interface PropTypes {
   mobile?: ReactNode[]
 }
 
-const CallToActionButton = ({ title, href, style = 'secondary', openInNewWindow= false }: CallToAction) => (
+const CallToActionButton = ({
+  title,
+  href,
+  style = 'secondary',
+  openInNewWindow = false,
+}: CallToAction) => (
   <a
     key={title}
     href={href}
     className={cn(style, 'cta')}
-    rel={openInNewWindow ? "noopener noreferrer" : ""}
-    target={openInNewWindow ? "_blank" : ""}
+    rel={openInNewWindow ? 'noopener noreferrer' : ''}
+    target={openInNewWindow ? '_blank' : ''}
   >
     {title}
   </a>

--- a/src/components/compressed-section.module.css.d.ts
+++ b/src/components/compressed-section.module.css.d.ts
@@ -1,6 +1,5 @@
 declare const styles: {
-  readonly "compressed": string;
-  readonly "expanded": string;
-};
-export = styles;
-
+  readonly compressed: string
+  readonly expanded: string
+}
+export = styles

--- a/src/components/footer.module.css.d.ts
+++ b/src/components/footer.module.css.d.ts
@@ -1,15 +1,14 @@
 declare const styles: {
-  readonly "footer": string;
-  readonly "contact": string;
-  readonly "copyright": string;
-  readonly "divider": string;
-  readonly "listTitle": string;
-  readonly "list": string;
-  readonly "item": string;
-  readonly "menuRow": string;
-  readonly "menuItem": string;
-  readonly "compRow": string;
-  readonly "compItem": string;
-};
-export = styles;
-
+  readonly footer: string
+  readonly contact: string
+  readonly copyright: string
+  readonly divider: string
+  readonly listTitle: string
+  readonly list: string
+  readonly item: string
+  readonly menuRow: string
+  readonly menuItem: string
+  readonly compRow: string
+  readonly compItem: string
+}
+export = styles

--- a/src/components/gdpr.tsx
+++ b/src/components/gdpr.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { CookieBanner } from '@palmabit/react-cookie-law'
+
+const getCookie = (cname: string) => {
+  const name = cname + '='
+  const decodedCookie = decodeURIComponent(document.cookie)
+  const ca = decodedCookie.split(';')
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i]
+    while (c.charAt(0) == ' ') {
+      c = c.substring(1)
+    }
+    if (c.indexOf(name) == 0) {
+      return c.substring(name.length, c.length)
+    }
+  }
+  return ''
+}
+
+const setCookie = (name: string, value: string, keep: number) => {
+  const d = new Date()
+  d.setTime(d.getTime() + keep * 24 * 60 * 60 * 1000)
+  const expires = 'expires=' + d.toUTCString()
+  document.cookie = name + '=' + value + ';' + expires + ';path=/'
+}
+
+const GDPR = () => (
+  <CookieBanner
+    message="Please select your cookie preferences"
+    wholeDomain={true}
+    policyLink={'/privacy'}
+    onAcceptStatistics={() => {
+      console.log('onAcceptStatistics', getCookie('gdpr_cookie_analytics'))
+      if (getCookie('gdpr_cookie_analytics') !== 'true') {
+        setCookie('gdpr_cookie_analytics', 'true', 365)
+        setTimeout(() => window.location.reload(), 10)
+      }
+    }}
+    showMarketingOption={false}
+    showPreferencesOption={false}
+    styles={{
+      dialog: {
+        bottom: 0,
+        position: 'fixed',
+        left: 0,
+        right: 0,
+        zIndex: 100000,
+        backgroundColor: 'rgb(248, 247, 247)',
+        padding: 10,
+      },
+      container: {
+        maxWidth: 960,
+        margin: '0 auto',
+        overflow: 'hidden',
+        display: 'flex',
+        alignItems: 'center',
+        // justifyContent: 'space-between',
+      },
+      message: {
+        fontSize: 14,
+      },
+      selectPane: {
+        flexGrow: 1,
+        marginLeft: 4,
+      },
+      checkbox: {
+        width: 14,
+        height: 14,
+      },
+      optionLabel: {
+        minHeight: 14,
+        fontSize: 14,
+        color: 'black',
+        display: 'inline-block',
+        padding: '0 0 0 6px',
+        position: 'relative',
+        top: 0,
+        left: 0,
+        zIndex: 1,
+        cursor: 'default',
+        verticalAlign: 'top',
+      },
+      policy: {
+        marginRight: 10,
+        textDecoration: 'underline',
+        color: 'black',
+        fontSize: 14,
+      },
+      button: {
+        border: 'none',
+        outline: 'none',
+        display: 'inline-block',
+        backgroundColor: 'rgb(0, 0, 0)',
+        padding: '5px 10px',
+        minWidth: 80,
+        color: 'rgb(255, 255, 255)',
+        textDecoration: 'none',
+        fontSize: 14,
+        margin: '0px 5px',
+        textAlign: 'center',
+        whiteSpace: 'nowrap',
+        cursor: 'pointer',
+      },
+    }}
+  />
+)
+
+export default GDPR

--- a/src/components/header.module.css.d.ts
+++ b/src/components/header.module.css.d.ts
@@ -1,12 +1,11 @@
 declare const styles: {
-  readonly "header": string;
-  readonly "logo": string;
-  readonly "projectName": string;
-  readonly "projectNameTiny": string;
-  readonly "menu": string;
-  readonly "leftMenu": string;
-  readonly "rightMenu": string;
-  readonly "iconMenu": string;
-};
-export = styles;
-
+  readonly header: string
+  readonly logo: string
+  readonly projectName: string
+  readonly projectNameTiny: string
+  readonly menu: string
+  readonly leftMenu: string
+  readonly rightMenu: string
+  readonly iconMenu: string
+}
+export = styles

--- a/src/components/hero.module.css.d.ts
+++ b/src/components/hero.module.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "hero": string;
-};
-export = styles;
-
+  readonly hero: string
+}
+export = styles

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -15,13 +15,18 @@ interface PropTypes {
   cta: CallToAction[]
 }
 
-const CallToActionButton = ({ title, href, style = 'secondary', openInNewWindow= false }: CallToAction) => (
+const CallToActionButton = ({
+  title,
+  href,
+  style = 'secondary',
+  openInNewWindow = false,
+}: CallToAction) => (
   <a
     key={title}
     href={href}
     className={cn(style, 'cta')}
-    rel={openInNewWindow ? "noopener noreferrer" : ""}
-    target={openInNewWindow ? "_blank" : ""}
+    rel={openInNewWindow ? 'noopener noreferrer' : ''}
+    target={openInNewWindow ? '_blank' : ''}
   >
     {title}
   </a>

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react'
+import { CookieBanner } from '@palmabit/react-cookie-law'
 
 // DO NOT CHANGE THE ORDER OF THESE
 import 'normalize.css'
@@ -12,12 +13,16 @@ import { Menu, IconMenu } from './header'
 import Header from './header'
 import Announcement from './announcement'
 import Footer from './footer'
+import GDPR from './gdpr'
 
 const defaultMenu: Menu = [
   { title: 'Docs', href: '/docs' },
   { title: 'Blog', path: '/blog' },
   { title: 'Jobs', href: 'https://github.com/ory/jobs' },
-  { title: 'Support', href: 'https://github.com/ory/open-source-support/blob/master/README.md' },
+  {
+    title: 'Support',
+    href: 'https://github.com/ory/open-source-support/blob/master/README.md',
+  },
 ]
 
 const defaultIconMenu = ({
@@ -50,6 +55,7 @@ const Layout = ({
     <Header appendix={appendix} menu={menu} icons={icons({ githubLink })} />
     <main>{children}</main>
     <Footer />
+    <GDPR />
   </div>
 )
 

--- a/src/components/mobile-menu.module.css.d.ts
+++ b/src/components/mobile-menu.module.css.d.ts
@@ -1,10 +1,9 @@
 declare const styles: {
-  readonly "navIcon": string;
-  readonly "divider": string;
-  readonly "show": string;
-  readonly "navContainer": string;
-  readonly "isActive": string;
-  readonly "navItems": string;
-};
-export = styles;
-
+  readonly navIcon: string
+  readonly divider: string
+  readonly show: string
+  readonly navContainer: string
+  readonly isActive: string
+  readonly navItems: string
+}
+export = styles

--- a/src/components/newsletter.module.css.d.ts
+++ b/src/components/newsletter.module.css.d.ts
@@ -1,8 +1,7 @@
 declare const styles: {
-  readonly "newsletter": string;
-  readonly "right": string;
-  readonly "light": string;
-  readonly "form": string;
-};
-export = styles;
-
+  readonly newsletter: string
+  readonly right: string
+  readonly light: string
+  readonly form: string
+}
+export = styles

--- a/src/components/profile.module.css
+++ b/src/components/profile.module.css
@@ -7,7 +7,6 @@
     margin-bottom: 0 !important;
   }
 
-
   & h4 {
     font-style: normal;
     font-weight: 500;
@@ -53,15 +52,13 @@
         margin-bottom: 34px;
       }
 
-        &:last-child {
-          margin-bottom: 34px !important;
-        }
+      &:last-child {
+        margin-bottom: 34px !important;
       }
     }
+  }
 }
 
 .space {
   margin-left: 20px;
 }
-
-

--- a/src/components/profile.module.css.d.ts
+++ b/src/components/profile.module.css.d.ts
@@ -1,7 +1,6 @@
 declare const styles: {
-  readonly "profile": string;
-  readonly "social": string;
-  readonly "space": string;
-};
-export = styles;
-
+  readonly profile: string
+  readonly social: string
+  readonly space: string
+}
+export = styles

--- a/src/components/profile.tsx
+++ b/src/components/profile.tsx
@@ -16,7 +16,7 @@ interface PropTypes {
 export enum SocialNetworks {
   twitter,
   github,
-  linkedin
+  linkedin,
 }
 
 type SocialLinks = {
@@ -24,45 +24,41 @@ type SocialLinks = {
   href: string
 }
 
-const socialWithIcon = ({href, network}: SocialLinks) => {
+const socialWithIcon = ({ href, network }: SocialLinks) => {
   let icon
   let alt
   switch (network) {
     case SocialNetworks.github:
       icon = Github
-      alt = "GitHub"
+      alt = 'GitHub'
       break
     case SocialNetworks.linkedin:
       icon = Linkedin
-      alt = "Linkedin"
+      alt = 'Linkedin'
       break
     case SocialNetworks.twitter:
       icon = Twitter
-      alt = "Twitter"
+      alt = 'Twitter'
       break
   }
 
   return {
     href,
     icon,
-    alt
+    alt,
   }
 }
 
-const Profile = ({
-                   name,
-                   img,
-                   social
-                 }: PropTypes) => (
+const Profile = ({ name, img, social }: PropTypes) => (
   <div className={styles.profile}>
     <div>
       <Img fixed={img} alt={name} />
     </div>
     <div className={cn(styles.space)}>
       <h4>{name}</h4>
-      <>{social.map(socialWithIcon).map(({ icon, href, alt }) => (
-          <a href={href}
-            key={href}>
+      <>
+        {social.map(socialWithIcon).map(({ icon, href, alt }) => (
+          <a href={href} key={href}>
             <img className={cn(styles.social)} src={icon} alt={alt} />
           </a>
         ))}

--- a/src/components/projects.module.css.d.ts
+++ b/src/components/projects.module.css.d.ts
@@ -1,11 +1,10 @@
 declare const styles: {
-  readonly "information": string;
-  readonly "projects": string;
-  readonly "project": string;
-  readonly "kratos": string;
-  readonly "hydra": string;
-  readonly "oathkeeper": string;
-  readonly "keto": string;
-};
-export = styles;
-
+  readonly information: string
+  readonly projects: string
+  readonly project: string
+  readonly kratos: string
+  readonly hydra: string
+  readonly oathkeeper: string
+  readonly keto: string
+}
+export = styles

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -6,13 +6,7 @@ import { brandPrefix, projects } from '../config'
 import { Link } from 'gatsby'
 
 const Projects = () => (
-  <div
-    className={cn(
-      styles.section,
-      styles.dark,
-      'is-dark-background',
-    )}
-  >
+  <div className={cn(styles.section, styles.dark, 'is-dark-background')}>
     <div className="container-fluid">
       <div className="row">
         <div
@@ -36,7 +30,10 @@ const Projects = () => (
             >
               {projects.map(({ title, description, path, id }) => (
                 <div className="col-lg-6 col-md-12 col-sm-12" key={title}>
-                  <Link className={cn(projectStyles.project, projectStyles[id])} to={path}>
+                  <Link
+                    className={cn(projectStyles.project, projectStyles[id])}
+                    to={path}
+                  >
                     <div>
                       <h4>{title}</h4>
                       <p>{description}</p>

--- a/src/components/responsive-section.module.css.d.ts
+++ b/src/components/responsive-section.module.css.d.ts
@@ -1,7 +1,6 @@
 declare const styles: {
-  readonly "section": string;
-  readonly "light": string;
-  readonly "dark": string;
-};
-export = styles;
-
+  readonly section: string
+  readonly light: string
+  readonly dark: string
+}
+export = styles

--- a/src/components/section.module.css.d.ts
+++ b/src/components/section.module.css.d.ts
@@ -1,7 +1,6 @@
 declare const styles: {
-  readonly "section": string;
-  readonly "light": string;
-  readonly "dark": string;
-};
-export = styles;
-
+  readonly section: string
+  readonly light: string
+  readonly dark: string
+}
+export = styles

--- a/src/components/stats.module.css.d.ts
+++ b/src/components/stats.module.css.d.ts
@@ -1,10 +1,9 @@
 declare const styles: {
-  readonly "stats": string;
-  readonly "items": string;
-  readonly "item": string;
-  readonly "amount": string;
-  readonly "title": string;
-  readonly "description": string;
-};
-export = styles;
-
+  readonly stats: string
+  readonly items: string
+  readonly item: string
+  readonly amount: string
+  readonly title: string
+  readonly description: string
+}
+export = styles

--- a/src/components/team.module.css.d.ts
+++ b/src/components/team.module.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "team": string;
-};
-export = styles;
-
+  readonly team: string
+}
+export = styles

--- a/src/components/team.tsx
+++ b/src/components/team.tsx
@@ -44,12 +44,12 @@ const Team = () => {
                   social={[
                     {
                       network: SocialNetworks.github,
-                      href: 'https://github.com/aeneasr'
+                      href: 'https://github.com/aeneasr',
                     },
                     {
                       network: SocialNetworks.linkedin,
-                      href: 'https://www.linkedin.com/in/aeneasr'
-                    }
+                      href: 'https://www.linkedin.com/in/aeneasr',
+                    },
                   ]}
                   img={data.aeneas.childImageSharp.fixed}
                 />
@@ -58,12 +58,12 @@ const Team = () => {
                   social={[
                     {
                       network: SocialNetworks.github,
-                      href: 'https://github.com/tacurran'
+                      href: 'https://github.com/tacurran',
                     },
                     {
                       network: SocialNetworks.linkedin,
-                      href: 'https://www.linkedin.com/in/thomasaidancurran/'
-                    }
+                      href: 'https://www.linkedin.com/in/thomasaidancurran/',
+                    },
                   ]}
                   img={data.thomas.childImageSharp.fixed}
                 />
@@ -72,12 +72,12 @@ const Team = () => {
                   social={[
                     {
                       network: SocialNetworks.github,
-                      href: 'https://github.com/jaredpreston'
+                      href: 'https://github.com/jaredpreston',
                     },
                     {
                       network: SocialNetworks.linkedin,
-                      href: 'https://www.linkedin.com/in/jaredpreston'
-                    }
+                      href: 'https://www.linkedin.com/in/jaredpreston',
+                    },
                   ]}
                   img={data.jared.childImageSharp.fixed}
                 />
@@ -92,19 +92,19 @@ const Team = () => {
               engineering.
             </p>
           </div>
-          <div className={cn( 'hidden-sm hidden-md col-lg-offset-2 col-lg-4')}>
+          <div className={cn('hidden-sm hidden-md col-lg-offset-2 col-lg-4')}>
             <>
               <Profile
                 name="Aeneas Rekkas"
                 social={[
                   {
                     network: SocialNetworks.github,
-                    href: 'https://github.com/aeneasr'
+                    href: 'https://github.com/aeneasr',
                   },
                   {
                     network: SocialNetworks.linkedin,
-                    href: 'https://www.linkedin.com/in/aeneasr'
-                  }
+                    href: 'https://www.linkedin.com/in/aeneasr',
+                  },
                 ]}
                 img={data.aeneas.childImageSharp.fixed}
               />
@@ -113,12 +113,12 @@ const Team = () => {
                 social={[
                   {
                     network: SocialNetworks.github,
-                    href: 'https://github.com/tacurran'
+                    href: 'https://github.com/tacurran',
                   },
                   {
                     network: SocialNetworks.linkedin,
-                    href: 'https://www.linkedin.com/in/thomasaidancurran/'
-                  }
+                    href: 'https://www.linkedin.com/in/thomasaidancurran/',
+                  },
                 ]}
                 img={data.thomas.childImageSharp.fixed}
               />
@@ -127,12 +127,12 @@ const Team = () => {
                 social={[
                   {
                     network: SocialNetworks.github,
-                    href: 'https://github.com/jaredpreston'
+                    href: 'https://github.com/jaredpreston',
                   },
                   {
                     network: SocialNetworks.linkedin,
-                    href: 'https://www.linkedin.com/in/jaredpreston'
-                  }
+                    href: 'https://www.linkedin.com/in/jaredpreston',
+                  },
                 ]}
                 img={data.jared.childImageSharp.fixed}
               />

--- a/src/components/thin-project-list.tsx
+++ b/src/components/thin-project-list.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { brandPrefix, projects } from '../config'
 import ThinProject from './thin-project'
 
-
 const ThinProjectList = () => (
   <div>
     {projects.map(({ id, descriptiveTitle, description, path, visual }) => (

--- a/src/components/thin-project.module.css.d.ts
+++ b/src/components/thin-project.module.css.d.ts
@@ -1,6 +1,5 @@
 declare const styles: {
-  readonly "thin": string;
-  readonly "cap": string;
-};
-export = styles;
-
+  readonly thin: string
+  readonly cap: string
+}
+export = styles

--- a/src/components/thin-project.tsx
+++ b/src/components/thin-project.tsx
@@ -13,13 +13,13 @@ interface PropTypes {
 }
 
 const ThinProject = ({
-                       title,
-                       description,
-                       learn,
-                       theme,
-                       href,
-                       visual,
-                     }: PropTypes) => (
+  title,
+  description,
+  learn,
+  theme,
+  href,
+  visual,
+}: PropTypes) => (
   <div className={cn(`theme-${theme}`, styles.thin)}>
     <div className="container-fluid">
       <div className={cn('row middle-lg')}>
@@ -34,7 +34,7 @@ const ThinProject = ({
         </div>
         <div className="col-lg-offset-2 col-lg-4 col-md-offset-1 col-md-10 col-sm-offset-1 col-sm-10">
           <Link to={href}>
-            <img src={visual} alt={`${title} visualized`}/>
+            <img src={visual} alt={`${title} visualized`} />
           </Link>
         </div>
       </div>

--- a/src/components/vertical-divider.module.css.d.ts
+++ b/src/components/vertical-divider.module.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "divider": string;
-};
-export = styles;
-
+  readonly divider: string
+}
+export = styles

--- a/src/html.js
+++ b/src/html.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 import icon from './images/icon/apple-touch-icon-57x57.png'
@@ -50,15 +50,6 @@ export default function HTML(props) {
           content="width=device-width, initial-scale=1, shrink-to-fit=no"
         />
         {props.headComponents}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-MJD22FZ');`,
-          }}
-        />
       </head>
       <body {...props.bodyAttributes}>
         {props.preBodyComponents}
@@ -71,30 +62,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           dangerouslySetInnerHTML={{ __html: props.body }}
         />
         {props.postBodyComponents}
-        <script
-          async
-          src="https://www.googletagmanager.com/gtag/js?id=UA-71865250-1"
-        />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-
-gtag('config', 'UA-71865250-1');`,
-          }}
-        />
-        <noscript>
-          <iframe
-            src="https://www.googletagmanager.com/ns.html?id=GTM-MJD22FZ"
-            style={{
-              height: 0,
-              width: 0,
-              display: 'none',
-              visibility: 'hidden',
-            }}
-          />
-        </noscript>
       </body>
     </html>
   )

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -3,8 +3,6 @@ import React from 'react'
 import SEO from '../components/seo'
 import Team from '../components/team'
 
-
-
 const AboutPage = () => (
   <Layout>
     <SEO

--- a/src/pages/blog.module.css.d.ts
+++ b/src/pages/blog.module.css.d.ts
@@ -1,11 +1,10 @@
 declare const styles: {
-  readonly "pageTitle": string;
-  readonly "postList": string;
-  readonly "postItem": string;
-  readonly "postOverline": string;
-  readonly "postTitle": string;
-  readonly "postTeaser": string;
-  readonly "postLink": string;
-};
-export = styles;
-
+  readonly pageTitle: string
+  readonly postList: string
+  readonly postItem: string
+  readonly postOverline: string
+  readonly postTitle: string
+  readonly postTeaser: string
+  readonly postLink: string
+}
+export = styles

--- a/src/pages/blog/kratos-knative-demo.md
+++ b/src/pages/blog/kratos-knative-demo.md
@@ -1,7 +1,7 @@
 ---
 published: true
 path: '/kratos-knative-demo/'
-title: 'ORY Kratos on Knative' 
+title: 'ORY Kratos on Knative'
 metaTitle: 'ORY Kratos on Knative'
 publishedAt: '2020-10-01'
 author: 'Kim Neunert'
@@ -11,43 +11,58 @@ subtitle: >
 
 overline: >
   ORY Kratos and knative in minikube: Have your cake and eat it too ...
-  
+
 teaser: >
-   We evaluated knative as a platform for running kratos and here is what we found out ...
+  We evaluated knative as a platform for running kratos and here is what we
+  found out ...
 
 metaDescription: >
-   We evaluated knative as a platform for running kratos and here is what we found out ...
+  We evaluated knative as a platform for running kratos and here is what we
+  found out ...
 
 category: Tutorial
 ---
 
 Serverless computing is a hot topic these days, and so is vendor lock in.
-Knative [https://knative.dev/] looks like something that addresses both points: You can have the cake and eat it too. For sure, there is always some downsides and that should be discussed elsewhere.
-For now, let's simply assume you're interested in ORY's cloud native software applications for security and identity management. And you want to run it on Knative. In order to examine that it's best to have Knative running on your computer.
+Knative [https://knative.dev/] looks like something that addresses both points:
+You can have the cake and eat it too. For sure, there is always some downsides
+and that should be discussed elsewhere. For now, let's simply assume you're
+interested in ORY's cloud native software applications for security and identity
+management. And you want to run it on Knative. In order to examine that it's
+best to have Knative running on your computer.
 
 ## Prerequisites
-Kubernetes and Minikube are high performance resource intensive applications. As a minimum requirement, we suggest 16GB of RAM.
-This example was developed on UbuntuLinux/minikube/kvm2 and it should definitely work with [other setups](https://www.youtube.com/watch?v=q6kyHDleioA&t=202s).
+
+Kubernetes and Minikube are high performance resource intensive applications. As
+a minimum requirement, we suggest 16GB of RAM. This example was developed on
+UbuntuLinux/minikube/kvm2 and it should definitely work with
+[other setups](https://www.youtube.com/watch?v=q6kyHDleioA&t=202s).
 
 We're using a "make" utility that fulfills all the other components:
+
 ```
 # Ubuntu
 sudo apt install build-essential
 # MacOS
 brew install make
 ```
-We'll also need Helm. Please download the helm-binary in a local .bin directory for later usage.
+
+We'll also need Helm. Please download the helm-binary in a local .bin directory
+for later usage.
 
 `make init`
+
 ```
 mkdir -p .bin
 HELM_INSTALL_DIR=./.bin bash <(curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) --no-sudo --version v3.1.2
 ```
 
 ## minikube
+
 Minikube is where it starts. We'll need at least 8GB of RAM for this.
 
-*`make minikube-init`*
+_`make minikube-init`_
+
 ```
 minikube delete -p ory-knative
 @echo "Waiting for minikube delete..."
@@ -63,19 +78,28 @@ minikube start -p ory-knative \
 kubectl config use-context ory-knative
 ```
 
-It will probably take some time and you'll have a fully running kubernetes available afterwards. The last command will also make this cluster available to your kubectl-command by default. 
-Let's test it with some commands, e.g. 
-`kubectl cluster-info`
-We want to have the kubernetes dashboard available as well. Also, a cluster does not make much sense if you can't access it via a Loadbalancer. In Minikube, there is a built-in tool that simulates a `LoadBalancer: tunnel`. However, the `tunnel` command is not coming back but will continue to run in the foreground. For that reason open a second shell terminal session.
-`make mikikube-access`
+It will probably take some time and you'll have a fully running kubernetes
+available afterwards. The last command will also make this cluster available to
+your kubectl-command by default. Let's test it with some commands, e.g.
+`kubectl cluster-info` We want to have the kubernetes dashboard available as
+well. Also, a cluster does not make much sense if you can't access it via a
+Loadbalancer. In Minikube, there is a built-in tool that simulates a
+`LoadBalancer: tunnel`. However, the `tunnel` command is not coming back but
+will continue to run in the foreground. For that reason open a second shell
+terminal session. `make mikikube-access`
+
 ```
 minikube -p ory-knative dashboard & # tidy this up is to to user
 minikube -p ory-knative tunnel
 ```
 
 ## Istio and Knative
-We'll install Istio [https://https:/istio.io/] version 1.3.6. That is the one recommended in the [knative-installation-documentation](https://knative.dev/v0.12-docs/install/installing-istio/). This takes about 30 seconds.
-`make istio-init`
+
+We'll install Istio [https://https:/istio.io/] version 1.3.6. That is the one
+recommended in the
+[knative-installation-documentation](https://knative.dev/v0.12-docs/install/installing-istio/).
+This takes about 30 seconds. `make istio-init`
+
 ```
 ISTIO_VERSION=1.3.6 .bin/getLatestIstio
 cd istio-1.3.6
@@ -113,9 +137,12 @@ echo "Let's wait on the pods coming up in istio-system"
 while [[ "$$(kubectl get pods --field-selector=status.phase!=Running -n istio-system  -o json | jq '.items[].metadata.name' | wc -l )" != 0 ]]; do echo "waiting another 5 secs of approx 30 secs..."; sleep 5; done
 cd ..
 ```
-The knative-installation takes 4 minutes approximately. It's effectively simply applying yaml-files directly from Github:
+
+The knative-installation takes 4 minutes approximately. It's effectively simply
+applying yaml-files directly from Github:
 
 `make knative-init`
+
 ```
 kubectl apply --selector knative.dev/crd-install=true \
 --filename https://github.com/knative/serving/releases/download/v0.12.0/serving.yaml \
@@ -123,12 +150,14 @@ kubectl apply --selector knative.dev/crd-install=true \
 --filename https://github.com/knative/serving/releases/download/v0.12.0/monitoring.yaml || true
 kubectl apply --filename https://github.com/knative/serving/releases/download/v0.12.0/serving.yaml \
 --filename https://github.com/knative/eventing/releases/download/v0.12.0/eventing.yaml \
---filename https://github.com/knative/serving/releases/download/v0.12.0/monitoring.yaml 
+--filename https://github.com/knative/serving/releases/download/v0.12.0/monitoring.yaml
 ```
 
-You can check whether the installation is finished by listing resources that are not yet in "RUNNING" state in each of the 3 knative specific namespaces:
+You can check whether the installation is finished by listing resources that are
+not yet in "RUNNING" state in each of the 3 knative specific namespaces:
 
 `make knative-check`
+
 ```
 kubectl get pods --field-selector=status.phase!=Running -n -o jsonpath='{.items[*].metadata.name}' -n knative-serving | tr -s '[[:space:]]' '\n'
 kubectl get pods --field-selector=status.phase!=Running -n -o jsonpath='{.items[*].metadata.name}' -n knative-eventing | tr -s '[[:space:]]' '\n'
@@ -137,24 +166,35 @@ knative-serving  -o json | jq '.items[].metadata.name' | wc -l )" != 0 ]]
 ```
 
 ## Deploy an Go-container example and the ORY Oathkeeper demo
-The Knative documentation has a very [simplistic hello world example](https://knative.dev/docs/serving/getting-started-knative-app/), which we'll use here as a kind of probe to test the funtionality. It's a very simple go-container running a webserver returning "Hello Go Sample v1!".
 
+The Knative documentation has a very
+[simplistic hello world example](https://knative.dev/docs/serving/getting-started-knative-app/),
+which we'll use here as a kind of probe to test the funtionality. It's a very
+simple go-container running a webserver returning "Hello Go Sample v1!".
 
 `make deploy-probe`
+
 ```
 kubectl apply --filename probe-helloworld.yaml
 ./modify_etchosts.sh $$(kubectl get route helloworld-go --output jsonpath="{.status.url}" | cut -d"/" -f3)
 printf "\n\n    --> Access the probe at  $$(kubectl get route helloworld-go --output jsonpath='{.status.url}')"
-```	
+```
 
-The code above will also modify your /etc/hosts file in order to make the DNS-name resolvable: [http://helloworld-go.default.example.com](http://helloworld-go.default.example.com).
+The code above will also modify your /etc/hosts file in order to make the
+DNS-name resolvable:
+[http://helloworld-go.default.example.com](http://helloworld-go.default.example.com).
 
-So if the example is not working properly by returning "Hello Go Sample v1!", please check your hostfile. The above DNS-name needs to resolve to the IP-address that you get by running `kubectl get svc istio-ingressgateway -n istio-system --output jsonpath="{.status.loadBalancer.ingress[0].ip}"`. That's especially important if you've purged and recreated the cluster.
-Also make sure that the tunnel process, mentioned above, is up and running.
+So if the example is not working properly by returning "Hello Go Sample v1!",
+please check your hostfile. The above DNS-name needs to resolve to the
+IP-address that you get by running
+`kubectl get svc istio-ingressgateway -n istio-system --output jsonpath="{.status.loadBalancer.ingress[0].ip}"`.
+That's especially important if you've purged and recreated the cluster. Also
+make sure that the tunnel process, mentioned above, is up and running.
 
 The next step is to deploy a very basic oathkeeper-demo.
 
 `make deploy-oathkeeper-demo`
+
 ```
 		kubectl create ns demo || true
 		helm template --name-template=demo --namespace=demo \
@@ -174,22 +214,39 @@ The next step is to deploy a very basic oathkeeper-demo.
 		printf "\n\n    --> Access the demo at  $$(kubectl get route demo-oathkeeper -n demo --output jsonpath='{.status.url}')/authenticator/anonymous/authorizer/allow/mutator/id_token "
 ```
 
-The trick here is to use some Helm variables in a way that suppress the creation of deployment- and pod-yaml-files. After that, we can apply the config map and the secret without any modifications.
-The ksvc-yaml script needs to be handcrafted, though. While its creation was quite simple and straightforward, the file can also be reviewed in Github:
-* Create a stub by copying the above helloworld-example and adjust the name, label and other meta-values
-* Copy the spec from the created deployment part of the oathkeeper-helm-charts and replace the spec of our newly created file
-* Remove the liveness- and readyness-probe-sections (commented in our case)
-* Remove the admin-part port-section. A ksvc may only have one port exposed. We will need to duplicate the ksvc in order to also expose Oathkeeper's admin-port (attention: security-risk!)
-* Replace the name of the exposed port as "http1"
+The trick here is to use some Helm variables in a way that suppress the creation
+of deployment- and pod-yaml-files. After that, we can apply the config map and
+the secret without any modifications. The ksvc-yaml script needs to be
+handcrafted, though. While its creation was quite simple and straightforward,
+the file can also be reviewed in Github:
 
-So applying that yaml-file should make the service available and you can test it via [http://demo-oathkeeper.demo.example.com/authenticator/anonymous/authorizer/allow/mutator/id_token](http://demo-oathkeeper.demo.example.com/authenticator/anonymous/authorizer/allow/mutator/id_token).
-That's not very usefull, but we have to continue as we're only doing a very shallow example here on Knative and Ory software.
+- Create a stub by copying the above helloworld-example and adjust the name,
+  label and other meta-values
+- Copy the spec from the created deployment part of the oathkeeper-helm-charts
+  and replace the spec of our newly created file
+- Remove the liveness- and readyness-probe-sections (commented in our case)
+- Remove the admin-part port-section. A ksvc may only have one port exposed. We
+  will need to duplicate the ksvc in order to also expose Oathkeeper's
+  admin-port (attention: security-risk!)
+- Replace the name of the exposed port as "http1"
+
+So applying that yaml-file should make the service available and you can test it
+via
+[http://demo-oathkeeper.demo.example.com/authenticator/anonymous/authorizer/allow/mutator/id_token](http://demo-oathkeeper.demo.example.com/authenticator/anonymous/authorizer/allow/mutator/id_token).
+That's not very usefull, but we have to continue as we're only doing a very
+shallow example here on Knative and Ory software.
 
 ## Working on ORY Kratos
-The goal of this part was to make as much workable as possible from the  [ORY Kratos quickstart tutorial](https://www.ory.sh/kratos/docs/quickstart/). We won't get that far, but more about that later.
-But first another prerequisite: Running ORY Kratos requires an open source relational database system such as Postgres or something equivalent. Without fullfilling that, kratos-bootup will quickly fail. 
+
+The goal of this part was to make as much workable as possible from the
+[ORY Kratos quickstart tutorial](https://www.ory.sh/kratos/docs/quickstart/). We
+won't get that far, but more about that later. But first another prerequisite:
+Running ORY Kratos requires an open source relational database system such as
+Postgres or something equivalent. Without fullfilling that, kratos-bootup will
+quickly fail.
 
 `make deploy-psql`
+
 ```
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install kratos-psql bitnami/postgresql
@@ -198,11 +255,13 @@ helm install kratos-psql bitnami/postgresql
 This will also give you a hint on how to obtain the password:
 `kubectl get secret --namespace default kratos-psql-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode`
 
-As the whole database-connection-string is specified as dsn in the values.yaml file, you have to replace the PASSWORD in that file in line 28.
+As the whole database-connection-string is specified as dsn in the values.yaml
+file, you have to replace the PASSWORD in that file in line 28.
 
 Ok, guess we're ready to deploy ORY Kratos.
 
 `make deploy-kratos`
+
 ```
 kubectl create ns kratos-demo || true
 helm template --name-template=kratos-demo --namespace=kratos-demo \
@@ -214,10 +273,21 @@ kubectl apply -f ./kratos-helm/kratos/templates/configmap-config.yaml
 kubectl apply -f kratos_ksvc_public.yaml
 ```
 
-Other than on the oathkeeper-charts, we were not able to suppress the creation of the deployment/pod. So we needed to "post-process" the created file in order to split the different components in individual files. That's what the "helm-fan-out.sh" script is doing (thanks to [washtubs](https://github.com/washtubs) on this [issue](https://github.com/helm/helm/issues/4680#issuecomment-613201032)).
+Other than on the oathkeeper-charts, we were not able to suppress the creation
+of the deployment/pod. So we needed to "post-process" the created file in order
+to split the different components in individual files. That's what the
+"helm-fan-out.sh" script is doing (thanks to
+[washtubs](https://github.com/washtubs) on this
+[issue](https://github.com/helm/helm/issues/4680#issuecomment-613201032)).
 
-After that, we're selectively only applying the configmap and the secret. The ksvc-yaml is handcrafted again. In that case, we took most of that from investigating the [quickstart.yml](https://github.com/ory/kratos/blob/master/quickstart.yml). The values.yaml stuff (kratos.config) is coming from the [quickstart .kratos.yml](https://github.com/ory/kratos/blob/master/contrib/quickstart/kratos/email-password/.kratos.yml).
-Most of these values are not yet adapted though. So we can expect that things don't work, but let's check.
+After that, we're selectively only applying the configmap and the secret. The
+ksvc-yaml is handcrafted again. In that case, we took most of that from
+investigating the
+[quickstart.yml](https://github.com/ory/kratos/blob/master/quickstart.yml). The
+values.yaml stuff (kratos.config) is coming from the
+[quickstart .kratos.yml](https://github.com/ory/kratos/blob/master/contrib/quickstart/kratos/email-password/.kratos.yml).
+Most of these values are not yet adapted though. So we can expect that things
+don't work, but let's check.
 
 ```
 kubectl get  ksvc kratos -n kratos-demo
@@ -226,15 +296,21 @@ kubectl describe ksvc kratos -n kratos-demo
 kubectl describe configuration kratos -n kratos-demo
 ```
 
-the first two commands make sure that the pod is created. Remember, it's Knative, and it does that on request.
-The third command verifies that the configuration was successfully created:
+the first two commands make sure that the pod is created. Remember, it's
+Knative, and it does that on request. The third command verifies that the
+configuration was successfully created:
+
 ```
 Events:
   Type     Reason         Age                    From                Message
   ----     ------         ----                   ----                -------
   Normal   Created        6m25s                  service-controller  Created Configuration "kratos"
 ```
-And the last command is looking at the error messages in the logs that are copied to the Status. Conditions of the configuration-object for our convenience:
+
+And the last command is looking at the error messages in the logs that are
+copied to the Status. Conditions of the configuration-object for our
+convenience:
+
 ```
 Status:
   Conditions:
@@ -243,7 +319,9 @@ Status:
 time="2020-05-27T15:23:53Z" level=fatal msg="The configuration is invalid and could not be loaded." config_key[1]=urls validation_error[1]="validation failed"
 ```
 
-So the fatal-message tells us that something with these configuration-lines (values.yaml) is wrong:
+So the fatal-message tells us that something with these configuration-lines
+(values.yaml) is wrong:
+
 ```
     urls:
       login_ui: http://127.0.0.1:4455/auth/login
@@ -253,10 +331,22 @@ So the fatal-message tells us that something with these configuration-lines (val
       verify_ui: http://127.0.0.1:4455/verify
 ```
 
-We shouldn't be surprised! So we need the selfservice_node-application somewhere and we created a very basic ksvc-file for that in the Github-repo. But here are the main two issues we'd need to solve going forward:
-* ORY Kratos and the application need to share the same DNS-name in order to be able to communicate with cookies. That's not how things are working out-of-the-box in Knative where each service gets its own DNS-name.
-* The admin-port, which we haven't have deployed yet, needs to be protected somehow.
+We shouldn't be surprised! So we need the selfservice_node-application somewhere
+and we created a very basic ksvc-file for that in the Github-repo. But here are
+the main two issues we'd need to solve going forward:
 
-And that's the point where this small article ends. For now, we won't continue going down that path even though we assume that the first problem might be solvable by creating a [custom ingress gateway](https://knative.dev/docs/serving/setting-up-custom-ingress-gateway/.) or maybe even less invasive ([knative-ingress](https://knative.dev/docs/reference/serving-api/#networking.internal.knative.dev/v1alpha1.Ingress), [-ingress-spec](https://knative.dev/docs/reference/serving-api/#networking.internal.knative.dev/v1alpha1.IngressSpec)).
+- ORY Kratos and the application need to share the same DNS-name in order to be
+  able to communicate with cookies. That's not how things are working
+  out-of-the-box in Knative where each service gets its own DNS-name.
+- The admin-port, which we haven't have deployed yet, needs to be protected
+  somehow.
+
+And that's the point where this small article ends. For now, we won't continue
+going down that path even though we assume that the first problem might be
+solvable by creating a
+[custom ingress gateway](https://knative.dev/docs/serving/setting-up-custom-ingress-gateway/.)
+or maybe even less invasive
+([knative-ingress](https://knative.dev/docs/reference/serving-api/#networking.internal.knative.dev/v1alpha1.Ingress),
+[-ingress-spec](https://knative.dev/docs/reference/serving-api/#networking.internal.knative.dev/v1alpha1.IngressSpec)).
 
 Thanks for reading, hopefully it can help you in some way.

--- a/src/pages/blog/modern-application-architecture.md
+++ b/src/pages/blog/modern-application-architecture.md
@@ -7,13 +7,13 @@ publishedAt: '2020-09-03'
 author: 'Lee Atchison'
 
 subtitle: >
-   From monoliths to service-based architectures 
+  From monoliths to service-based architectures 
 
 overline: >
-   Modern application architecture
+  Modern application architecture
 
 teaser: >
-   A short introduction into modern application architecture
+  A short introduction into modern application architecture
 
 metaDescription: >
   How ORY builds modern application architecture
@@ -23,37 +23,63 @@ category: Article
 
 ## Motivation
 
-Modern software requires the use of modern application architectures. 
-Modern application architectures require moving away from monolithic systems and using service-based architectures.
+Modern software requires the use of modern application architectures. Modern
+application architectures require moving away from monolithic systems and using
+service-based architectures.
 
-Monolith applications are extremely hard to scale, both from a traffic scaling standpoint and from the standpoint of your ability to scale the size of your organization to work on the application. 
-The larger the monolith, the slower it is to make changes to the application, the fewer the people who can work on it and manage it effectively, and the greater the likelihood that traffic variations and growth will negatively impact availability.
+Monolith applications are extremely hard to scale, both from a traffic scaling
+standpoint and from the standpoint of your ability to scale the size of your
+organization to work on the application. The larger the monolith, the slower it
+is to make changes to the application, the fewer the people who can work on it
+and manage it effectively, and the greater the likelihood that traffic
+variations and growth will negatively impact availability.
 
 ## The General Idea
 
-Among other strategies, service-oriented architectures address these issues by offering greater flexibility in scaling based on traffic needs well as offering a scalable platform to enable larger development organizations to operate on the application, making it possible for applications themselves to become larger and more complex.
+Among other strategies, service-oriented architectures address these issues by
+offering greater flexibility in scaling based on traffic needs well as offering
+a scalable platform to enable larger development organizations to operate on the
+application, making it possible for applications themselves to become larger and
+more complex.
 
-Modern architecture principles such as service-based architectures aid scalability as well as availability. 
-Additionally, modern applications can improve scalability and reduce downtime by implementing best practices such as risk management, internal service level agreements, and the use of service levels.
-All of this with the goal of enhancing customer satisfaction.
+Modern architecture principles such as service-based architectures aid
+scalability as well as availability. Additionally, modern applications can
+improve scalability and reduce downtime by implementing best practices such as
+risk management, internal service level agreements, and the use of service
+levels. All of this with the goal of enhancing customer satisfaction.
 
-When applications grow, they become more complex and fragile, as well as they need to handle larger volumes of traffic. 
-These problems lead to a death spiral which leads to brownouts, blackouts and other service quality issues. 
-Modern applications use modern principles that reduce the brittleness of complexity and increase reliability as the application grows.
+When applications grow, they become more complex and fragile, as well as they
+need to handle larger volumes of traffic. These problems lead to a death spiral
+which leads to brownouts, blackouts and other service quality issues. Modern
+applications use modern principles that reduce the brittleness of complexity and
+increase reliability as the application grows.
 
 ## Application architecture at ORY
 
-Today, I’m working with the team at ORY to help them architect the next generation identity service. 
+Today, I’m working with the team at ORY to help them architect the next
+generation identity service.
 
-The ORY team understands these principles, which is why the ORY cloud product is being designed from the ground up as a modern, service-based architecture. 
-As they build ORY cloud, they are utilizing modern development techniques, and modern development and operation processes and procedures.
+The ORY team understands these principles, which is why the ORY cloud product is
+being designed from the ground up as a modern, service-based architecture. As
+they build ORY cloud, they are utilizing modern development techniques, and
+modern development and operation processes and procedures.
 
-This allows them to build a highly scalable, highly available, identity management service for everyone.
+This allows them to build a highly scalable, highly available, identity
+management service for everyone.
 
 ## Continue reading
 
-If you are interested in learning more about modern application architecture techniques to build a more scalable, highly available application, then you may be interested in [checking out my book](https://leeatchison.com/architectingforscale/?utm_source=ory&utm_medium=blog&utm_campaign=202008 "Architecting for Scale"), published by O’Reilly Media, titled Architecting for Scale. 
+If you are interested in learning more about modern application architecture
+techniques to build a more scalable, highly available application, then you may
+be interested in
+[checking out my book](https://leeatchison.com/architectingforscale/?utm_source=ory&utm_medium=blog&utm_campaign=202008 'Architecting for Scale'),
+published by O’Reilly Media, titled Architecting for Scale.
 
-If you’d like to learn more about me and my background in building modern application architectures, [check out some of my articles and presentations on these topics](https://leeatchison.com/?utm_source=ory&utm_medium=blog&utm_campaign=202008). 
+If you’d like to learn more about me and my background in building modern
+application architectures,
+[check out some of my articles and presentations on these topics](https://leeatchison.com/?utm_source=ory&utm_medium=blog&utm_campaign=202008).
 
-If you would like to engage me to help you solve some of your modern architecture concerns, please reach out to me via my consulting and advisory company, [Atchison Technology LLC](https://atchisontechnology.com/?utm_source=ory&utm_medium=blog&utm_campaign=202008).
+If you would like to engage me to help you solve some of your modern
+architecture concerns, please reach out to me via my consulting and advisory
+company,
+[Atchison Technology LLC](https://atchisontechnology.com/?utm_source=ory&utm_medium=blog&utm_campaign=202008).

--- a/src/pages/index.module.css.d.ts
+++ b/src/pages/index.module.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "avatar": string;
-};
-export = styles;
-
+  readonly avatar: string
+}
+export = styles

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -37,7 +37,7 @@ const IndexPage = () => (
     <Adopters onlyFeatured />
     <ThinProjectList />
     <Stats />
-    <Newsletter/>
+    <Newsletter />
     <Team />
   </Layout>
 )

--- a/src/pages/markdown/privacy.md
+++ b/src/pages/markdown/privacy.md
@@ -7,39 +7,91 @@ metaDescription: 'Read the ORY Privacy Policy.'
 lastUpdatedAt: 'May 28, 2020'
 ---
 
-This privacy policy outlines how we handle information that can be used to directly or indirectly identify an individual ("Personal Information") and describes the Personal Information collected by Ory Corp, through its websites, products, and applications that together constitute the Ory Corp service (“the Service”), and how and for what purposes it is collected and used.
+This privacy policy outlines how we handle information that can be used to
+directly or indirectly identify an individual ("Personal Information") and
+describes the Personal Information collected by Ory Corp, through its websites,
+products, and applications that together constitute the Ory Corp service (“the
+Service”), and how and for what purposes it is collected and used.
 
-We believe that Personal Information that is submitted by or collected from individuals is private. Ory Corp does not rent, sell, or otherwise share this Personal Information.
+We believe that Personal Information that is submitted by or collected from
+individuals is private. Ory Corp does not rent, sell, or otherwise share this
+Personal Information.
 
 ## Information Collected
 
-When using the Service you may enter, among other things, your name and / or email address which is used to provide, for example, the Ory newsletter and other notifications about updates to the Service. The information collected by Ory Corp is sent to servers located in countries around the world, including among others, countries in the European Economic Area (EAA) and the United States. When transferring and receiving information, Ory Corp follows generally accepted and recognized standards and best practices and in accordance with applicable laws and regulations and with the General Data Protection Regulation (GDPR).
- 
-The following are examples of the types of information we collect through the Service:
- 
-*Information you give to us.* We collect and store any personal information you submit to the Service by entering it or in some other manner. This includes identifying information, such as your name, address, email address, and phone number. Other examples of information that you might submit on the Service are about your location (such as ZIP code and/or country). We collect this information to provide you with information about Ory Corp’s products, keep you informed and up to date about the service, and to send you other notifications that are relevant to and useful to your use of the Service.
+When using the Service you may enter, among other things, your name and / or
+email address which is used to provide, for example, the Ory newsletter and
+other notifications about updates to the Service. The information collected by
+Ory Corp is sent to servers located in countries around the world, including
+among others, countries in the European Economic Area (EAA) and the United
+States. When transferring and receiving information, Ory Corp follows generally
+accepted and recognized standards and best practices and in accordance with
+applicable laws and regulations and with the General Data Protection Regulation
+(GDPR).
 
-We do not publicly display or provide access to personally identifying information. We do not sell, rent, or otherwise share the information.
+The following are examples of the types of information we collect through the
+Service:
 
-*Information collected using third party metrics and analytics services.* We use third party metrics and analytics services such as Google Analytics to collect information and to learn more about the visitors to our Service. We also do this to be able to gauge how effectively we are marketing the service. Information collected include third party tags and cookies, Ory cookies, browser metadata, and IP addresses among other things. We use the information collected to maintain a good Service experience and to help us understand who is visiting the Service from where and for what reasons. This information may be compiled and analyzed by Ory Corp.
+_Information you give to us._ We collect and store any personal information you
+submit to the Service by entering it or in some other manner. This includes
+identifying information, such as your name, address, email address, and phone
+number. Other examples of information that you might submit on the Service are
+about your location (such as ZIP code and/or country). We collect this
+information to provide you with information about Ory Corp’s products, keep you
+informed and up to date about the service, and to send you other notifications
+that are relevant to and useful to your use of the Service.
 
+We do not publicly display or provide access to personally identifying
+information. We do not sell, rent, or otherwise share the information.
+
+_Information collected using third party metrics and analytics services._ We use
+third party metrics and analytics services such as Google Analytics to collect
+information and to learn more about the visitors to our Service. We also do this
+to be able to gauge how effectively we are marketing the service. Information
+collected include third party tags and cookies, Ory cookies, browser metadata,
+and IP addresses among other things. We use the information collected to
+maintain a good Service experience and to help us understand who is visiting the
+Service from where and for what reasons. This information may be compiled and
+analyzed by Ory Corp.
 
 ## Messages and Notifications
 
-At times, we will notify you by email about updates, changes, and other service related information. We will never ask you for personal information in those notifications and communication, or in any other communication from Ory Corp.
+At times, we will notify you by email about updates, changes, and other service
+related information. We will never ask you for personal information in those
+notifications and communication, or in any other communication from Ory Corp.
 
 ## Links to Third Parties
 
-The Service may contain links to third party websites or services with which we may or may not have affiliation to Ory Corp. We do not share your personal information with those third parties, and are not responsible for their privacy practices.
+The Service may contain links to third party websites or services with which we
+may or may not have affiliation to Ory Corp. We do not share your personal
+information with those third parties, and are not responsible for their privacy
+practices.
 
 ## Policy for Children
 
-The Service is intended for general audiences and is not directed to children under the age of 16. We do not knowingly collect personal information from children under 16. If we become aware that a child under 16 has provided us with personal information without parental consent, we take steps to remove such information.
+The Service is intended for general audiences and is not directed to children
+under the age of 16. We do not knowingly collect personal information from
+children under 16. If we become aware that a child under 16 has provided us with
+personal information without parental consent, we take steps to remove such
+information.
 
 ## Security
 
-Ory Corp takes appropriate administrative, technical, physical and organizational security measures to protect your Personal Information from loss, theft, misuse and unauthorized access, disclosure, alteration and destruction. We follow generally accepted standards to protect the Personal Information submitted to us, both during transmission and once it is received, and comply with applicable laws and regulations. While we have taken reasonable steps to secure the Personal Information you provide to us, please be aware that despite our best efforts, no security measures are perfect or impenetrable, and no method of data transmission can be guaranteed against any interception or other type of misuse. Any information disclosed online is vulnerable to interception and misuse by unauthorized parties. Therefore, we cannot guarantee complete security if you provide Personal Information via the Service.
+Ory Corp takes appropriate administrative, technical, physical and
+organizational security measures to protect your Personal Information from loss,
+theft, misuse and unauthorized access, disclosure, alteration and destruction.
+We follow generally accepted standards to protect the Personal Information
+submitted to us, both during transmission and once it is received, and comply
+with applicable laws and regulations. While we have taken reasonable steps to
+secure the Personal Information you provide to us, please be aware that despite
+our best efforts, no security measures are perfect or impenetrable, and no
+method of data transmission can be guaranteed against any interception or other
+type of misuse. Any information disclosed online is vulnerable to interception
+and misuse by unauthorized parties. Therefore, we cannot guarantee complete
+security if you provide Personal Information via the Service.
 
 ## Changes to the Privacy Policy
 
-Ory Corp may revise this Privacy Policy from time to time. If changes are made, that in our sole discretion, are material, we will notify you either by posting a notice of such changes prior to implementing the change on the Service.
+Ory Corp may revise this Privacy Policy from time to time. If changes are made,
+that in our sole discretion, are material, we will notify you either by posting
+a notice of such changes prior to implementing the change on the Service.

--- a/src/pages/markdown/tos.md
+++ b/src/pages/markdown/tos.md
@@ -7,44 +7,160 @@ metaTitle: 'ORY Terms of Service'
 metaDescription: 'Read the Terms of Service.'
 ---
 
-The terms and conditions outlined below (the “Terms of Service”) constitute a contract between you and ORY Corp (“ORY”, “us”, “we”), a Pennsylvania State company, and govern your access to and use of the ory.sh and related sub-domains (collectively known as the "Website"). You agree to the Terms of Service by using or accessing the Website. Please note that we do not provide warranties for the Website. The Terms of Service also limits our liability. 
+The terms and conditions outlined below (the “Terms of Service”) constitute a
+contract between you and ORY Corp (“ORY”, “us”, “we”), a Pennsylvania State
+company, and govern your access to and use of the ory.sh and related sub-domains
+(collectively known as the "Website"). You agree to the Terms of Service by
+using or accessing the Website. Please note that we do not provide warranties
+for the Website. The Terms of Service also limits our liability.
 
-Unless otherwise stated, the contents of the Website including, but not limited to, the text and images contained herein and their arrangement are the property of ORY. All trademarks used or referred to in this Website are the property of their respective owners. Nothing contained in the Website shall be construed as conferring by implication or otherwise, any license or right to any copyright, patent, trademark or other proprietary interest of ORY or any third party. 
+Unless otherwise stated, the contents of the Website including, but not limited
+to, the text and images contained herein and their arrangement are the property
+of ORY. All trademarks used or referred to in this Website are the property of
+their respective owners. Nothing contained in the Website shall be construed as
+conferring by implication or otherwise, any license or right to any copyright,
+patent, trademark or other proprietary interest of ORY or any third party.
 
-These Terms of Service can be changed at any time without any notice to you. The most current version of these Terms of Services can be found and reviewed by clicking on the “terms of service” hyperlink on the Website. 
+These Terms of Service can be changed at any time without any notice to you. The
+most current version of these Terms of Services can be found and reviewed by
+clicking on the “terms of service” hyperlink on the Website.
 
-## Use of the Website 
-In using the Website you may not engage in, facilitate or further unlawful conduct. You may not use the Website in a way that harms us or our affiliates, or customers, or use any portion of the Website as a destination linked from any unsolicited bulk messages or unsolicited commercial messages ("spam"). You may not use any automated process or service to access and/or use the Website or use any unauthorized means to modify or reroute, or attempt to modify or reroute, the Website. You may not damage, disable, overburden, or impair the Website (or the network(s) connected to the Website) or interfere with anyone's use and enjoyment of the Website. 
+## Use of the Website
 
-## Account and Password 
-If your use of the Website requires you to open an account, you must complete the registration process by providing us with current, complete, and accurate information as prompted by the applicable registration form. You may have to choose a password and a user name. You are entirely responsible for maintaining the confidentiality of your password and any other non-public account information. Furthermore, you are entirely responsible for any and all activities that occur under your account. You agree to notify ORY immediately of any unauthorized use of your account or any other breach of security. ORY will not be liable for any loss that you may incur as a result of someone else using your user name, password, or account, either with or without your knowledge. However, you could be held liable for losses incurred by ORY or another party due to someone else using your user name, password, or account. 
+In using the Website you may not engage in, facilitate or further unlawful
+conduct. You may not use the Website in a way that harms us or our affiliates,
+or customers, or use any portion of the Website as a destination linked from any
+unsolicited bulk messages or unsolicited commercial messages ("spam"). You may
+not use any automated process or service to access and/or use the Website or use
+any unauthorized means to modify or reroute, or attempt to modify or reroute,
+the Website. You may not damage, disable, overburden, or impair the Website (or
+the network(s) connected to the Website) or interfere with anyone's use and
+enjoyment of the Website.
 
-## Content and Information 
-You alone are responsible for the content (Your Content) you submit to the Service. You assume all risks associated with Your Content, its accuracy, completeness or usefulness, or any disclosure by you of information in Your Content that makes you personally identifiable. You represent that you own, or have the necessary permissions to use, and authorize the use of, Your Content. 
+## Account and Password
 
-You may expose yourself to liability if, for example, Your Content violates any third-party right, including any copyright, trademark, patent, trade secret, moral right, privacy right, right of publicity, or any other intellectual property or proprietary right; contains material that is false, intentionally misleading, or defamatory; contains material that is unlawful, including illegal hate speech or pornography; exploits or otherwise harms minors; or violates or advocates the violation of any law or regulation. 
+If your use of the Website requires you to open an account, you must complete
+the registration process by providing us with current, complete, and accurate
+information as prompted by the applicable registration form. You may have to
+choose a password and a user name. You are entirely responsible for maintaining
+the confidentiality of your password and any other non-public account
+information. Furthermore, you are entirely responsible for any and all
+activities that occur under your account. You agree to notify ORY immediately of
+any unauthorized use of your account or any other breach of security. ORY will
+not be liable for any loss that you may incur as a result of someone else using
+your user name, password, or account, either with or without your knowledge.
+However, you could be held liable for losses incurred by ORY or another party
+due to someone else using your user name, password, or account.
 
-ORY reserves the right to remove or reinstate a user and other content from time to time at its sole discretion. For example, ORY may remove user content (e.g. a comment) if it violates these Terms of Service. ORY has no obligation to retain or provide copies of Your Content, nor does ORY guarantee any confidentiality with respect to Your Content. 
+## Content and Information
 
-The content and information provided on the Website is in most cases free of charge and for informational purposes only, and does not create a business or professional services relationship between you and ORY. Links on the Website may lead to services or sites not operated by ORY. No judgment or warranty is made with respect to such other services or sites and ORY takes no responsibility for such other sites or services. A link to another site or service is not an endorsement of that site or service. Any use you make of the information provided on the Website, or any site or service linked to by the Website, is at your own risk. 
+You alone are responsible for the content (Your Content) you submit to the
+Service. You assume all risks associated with Your Content, its accuracy,
+completeness or usefulness, or any disclosure by you of information in Your
+Content that makes you personally identifiable. You represent that you own, or
+have the necessary permissions to use, and authorize the use of, Your Content.
 
-You acknowledge that the Website may contain content, information, software, photos, video, text, graphics, music, sounds or other material (collectively the “Content”) that are protected by copyrights, patents, trademarks, trade secrets or other proprietary rights, and that these rights are valid and protected in all forms, media and technologies existing now or hereafter developed. 
+You may expose yourself to liability if, for example, Your Content violates any
+third-party right, including any copyright, trademark, patent, trade secret,
+moral right, privacy right, right of publicity, or any other intellectual
+property or proprietary right; contains material that is false, intentionally
+misleading, or defamatory; contains material that is unlawful, including illegal
+hate speech or pornography; exploits or otherwise harms minors; or violates or
+advocates the violation of any law or regulation.
 
-Modification of the Content or use of the Content for any other purpose, including use of any such Content on any other web site or networked computer environment is strictly prohibited. Except as otherwise expressly authorized in writing in advance by us, you agree not to reproduce, redistribute, sell, modify, rent, lease, loan, adapt, translate, create derivative works based (whether in whole or in part) on, decompile, reverse engineer, disassemble, or otherwise reduce all or any part of the Website, including the Content. 
+ORY reserves the right to remove or reinstate a user and other content from time
+to time at its sole discretion. For example, ORY may remove user content (e.g. a
+comment) if it violates these Terms of Service. ORY has no obligation to retain
+or provide copies of Your Content, nor does ORY guarantee any confidentiality
+with respect to Your Content.
 
-## Privacy 
-In order to operate and provide the Service, we collect certain information about you. We use and protect that information as described in our Privacy Policy. 
+The content and information provided on the Website is in most cases free of
+charge and for informational purposes only, and does not create a business or
+professional services relationship between you and ORY. Links on the Website may
+lead to services or sites not operated by ORY. No judgment or warranty is made
+with respect to such other services or sites and ORY takes no responsibility for
+such other sites or services. A link to another site or service is not an
+endorsement of that site or service. Any use you make of the information
+provided on the Website, or any site or service linked to by the Website, is at
+your own risk.
 
-## No Warranties 
-ORY provides the Service as-is, with all faults and as available with no guarantee to the accuracy or timeliness of information available from the Website. ORY gives no express warranties, guarantees or conditions and exclude any implied warranties. 
+You acknowledge that the Website may contain content, information, software,
+photos, video, text, graphics, music, sounds or other material (collectively the
+“Content”) that are protected by copyrights, patents, trademarks, trade secrets
+or other proprietary rights, and that these rights are valid and protected in
+all forms, media and technologies existing now or hereafter developed.
 
-## Hold Harmless 
-You agree to indemnify, defend and hold harmless Sprizzl, subsidiaries, affiliates, officers, directors, employees, consultants, agents, successors and assigns from any and all third party claims, liability, damages, costs or demands, including, but not limited to, attorneys' fees, arising from (i) your use of the Service, including, but not limited to, all content therein and any products or services obtained by you through the Service, (ii) the violation of these Terms of Service by you, (iii) the infringement by you (or other user of the Service using your account) of any intellectual property or other right of any person or entity; or (iv) your violation of any applicable law or regulation. 
+Modification of the Content or use of the Content for any other purpose,
+including use of any such Content on any other web site or networked computer
+environment is strictly prohibited. Except as otherwise expressly authorized in
+writing in advance by us, you agree not to reproduce, redistribute, sell,
+modify, rent, lease, loan, adapt, translate, create derivative works based
+(whether in whole or in part) on, decompile, reverse engineer, disassemble, or
+otherwise reduce all or any part of the Website, including the Content.
 
-## Limited Liability 
-You expressly agree that ORY shall not be liable for any indirect, incidental, special or consequential damages, including, but not limited to, damages for loss of profits, use, data or other intangibles, even if ORY has been advised of the possibility of such damages, resulting from the (i) use or the inability to use the service; (ii) cost of procurement of substitute goods and services; (iii) any goods or services purchased or obtained or content received or transactions entered into with ORY or a third party through the use of the service; (iv) inaccuracy of any information obtained from use of the service or reliance on such information; or (v) unauthorized access to your account or alteration of your account or data. You specifically agree that ORY is not responsible or liable to you or anyone else for any unlawful, harassing, defamatory, abusive, threatening, harmful, vulgar, obscene, sexually explicit or otherwise objectionable conduct or speech of any other party on or through the service, or for any infringement or violation of your rights by any other party, including, but not limited to, intellectual property rights, rights of publicity, or rights of privacy. 
+## Privacy
 
-## Governing Law and Jurisdiction 
-The Website is controlled and operated by ORY on servers located across the world, including in the United States and the European Union. ORY does not represent or warrant that the Website or any part thereof is appropriate or available for use in any particular jurisdiction.  Those who choose to access the Website do so on their own initiative and at their own risk, and are responsible for complying with all local laws, rules and regulations. ORY may limit the Website's availability, in whole or in part, to any person, geographic area or jurisdiction we choose, at any time and at our sole discretion.
+In order to operate and provide the Service, we collect certain information
+about you. We use and protect that information as described in our Privacy
+Policy.
 
-These Terms of Service do not, and shall not be construed to, create any partnership, joint venture, employer-employee, agency or franchisor-franchisee relationship between you and ORY. These Terms of Service shall be governed by and construed in accordance with the laws of Pennsylvania State, without giving effect to any principles of conflicts of law. You agree that any action at law or in equity arising out of or relating to these Terms of Service shall be filed only in the state or federal courts located in Pennsylvania State and you hereby consent and submit to the personal jurisdiction of such courts for the purposes of litigating any such action and you waive any jurisdictional, venue or inconvenient forum objections to such courts.
+## No Warranties
+
+ORY provides the Service as-is, with all faults and as available with no
+guarantee to the accuracy or timeliness of information available from the
+Website. ORY gives no express warranties, guarantees or conditions and exclude
+any implied warranties.
+
+## Hold Harmless
+
+You agree to indemnify, defend and hold harmless Sprizzl, subsidiaries,
+affiliates, officers, directors, employees, consultants, agents, successors and
+assigns from any and all third party claims, liability, damages, costs or
+demands, including, but not limited to, attorneys' fees, arising from (i) your
+use of the Service, including, but not limited to, all content therein and any
+products or services obtained by you through the Service, (ii) the violation of
+these Terms of Service by you, (iii) the infringement by you (or other user of
+the Service using your account) of any intellectual property or other right of
+any person or entity; or (iv) your violation of any applicable law or
+regulation.
+
+## Limited Liability
+
+You expressly agree that ORY shall not be liable for any indirect, incidental,
+special or consequential damages, including, but not limited to, damages for
+loss of profits, use, data or other intangibles, even if ORY has been advised of
+the possibility of such damages, resulting from the (i) use or the inability to
+use the service; (ii) cost of procurement of substitute goods and services;
+(iii) any goods or services purchased or obtained or content received or
+transactions entered into with ORY or a third party through the use of the
+service; (iv) inaccuracy of any information obtained from use of the service or
+reliance on such information; or (v) unauthorized access to your account or
+alteration of your account or data. You specifically agree that ORY is not
+responsible or liable to you or anyone else for any unlawful, harassing,
+defamatory, abusive, threatening, harmful, vulgar, obscene, sexually explicit or
+otherwise objectionable conduct or speech of any other party on or through the
+service, or for any infringement or violation of your rights by any other party,
+including, but not limited to, intellectual property rights, rights of
+publicity, or rights of privacy.
+
+## Governing Law and Jurisdiction
+
+The Website is controlled and operated by ORY on servers located across the
+world, including in the United States and the European Union. ORY does not
+represent or warrant that the Website or any part thereof is appropriate or
+available for use in any particular jurisdiction. Those who choose to access the
+Website do so on their own initiative and at their own risk, and are responsible
+for complying with all local laws, rules and regulations. ORY may limit the
+Website's availability, in whole or in part, to any person, geographic area or
+jurisdiction we choose, at any time and at our sole discretion.
+
+These Terms of Service do not, and shall not be construed to, create any
+partnership, joint venture, employer-employee, agency or franchisor-franchisee
+relationship between you and ORY. These Terms of Service shall be governed by
+and construed in accordance with the laws of Pennsylvania State, without giving
+effect to any principles of conflicts of law. You agree that any action at law
+or in equity arising out of or relating to these Terms of Service shall be filed
+only in the state or federal courts located in Pennsylvania State and you hereby
+consent and submit to the personal jurisdiction of such courts for the purposes
+of litigating any such action and you waive any jurisdictional, venue or
+inconvenient forum objections to such courts.

--- a/src/styles/global.css.d.ts
+++ b/src/styles/global.css.d.ts
@@ -1,6 +1,5 @@
 declare const styles: {
-  readonly "responsive": string;
-  readonly "embedVideoContainer": string;
-};
-export = styles;
-
+  readonly responsive: string
+  readonly embedVideoContainer: string
+}
+export = styles

--- a/src/styles/grid.css.d.ts
+++ b/src/styles/grid.css.d.ts
@@ -1,29 +1,28 @@
 declare const styles: {
-  readonly "containerFluid": string;
-  readonly "row": string;
-  readonly "topSm": string;
-  readonly "middleSm": string;
-  readonly "bottomSm": string;
-  readonly "mobileOffset64": string;
-  readonly "mobileOffset32": string;
-  readonly "mobileOffset16": string;
-  readonly "mobileOffset8": string;
-  readonly "centerMobile": string;
-  readonly "hiddenSm": string;
-  readonly "hiddenMd": string;
-  readonly "hiddenLg": string;
-  readonly "colSm": string;
-  readonly "colSmOffset": string;
-  readonly "topMd": string;
-  readonly "middleMd": string;
-  readonly "bottomMd": string;
-  readonly "colMd": string;
-  readonly "colMdOffset": string;
-  readonly "topLg": string;
-  readonly "middleLg": string;
-  readonly "bottomLg": string;
-  readonly "colLg": string;
-  readonly "colLgOffset": string;
-};
-export = styles;
-
+  readonly containerFluid: string
+  readonly row: string
+  readonly topSm: string
+  readonly middleSm: string
+  readonly bottomSm: string
+  readonly mobileOffset64: string
+  readonly mobileOffset32: string
+  readonly mobileOffset16: string
+  readonly mobileOffset8: string
+  readonly centerMobile: string
+  readonly hiddenSm: string
+  readonly hiddenMd: string
+  readonly hiddenLg: string
+  readonly colSm: string
+  readonly colSmOffset: string
+  readonly topMd: string
+  readonly middleMd: string
+  readonly bottomMd: string
+  readonly colMd: string
+  readonly colMdOffset: string
+  readonly topLg: string
+  readonly middleLg: string
+  readonly bottomLg: string
+  readonly colLg: string
+  readonly colLgOffset: string
+}
+export = styles

--- a/src/styles/typography.css.d.ts
+++ b/src/styles/typography.css.d.ts
@@ -1,10 +1,9 @@
 declare const styles: {
-  readonly "secondary": string;
-  readonly "cta": string;
-  readonly "primary": string;
-  readonly "visited": string;
-  readonly "tertiary": string;
-  readonly "remarkEmoji": string;
-};
-export = styles;
-
+  readonly secondary: string
+  readonly cta: string
+  readonly primary: string
+  readonly visited: string
+  readonly tertiary: string
+  readonly remarkEmoji: string
+}
+export = styles

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,3 +1,7 @@
+declare module '@palmabit/react-cookie-law' {
+  export const CookieBanner: any
+}
+
 declare module '*.svg' {
   const content: any
   export default content


### PR DESCRIPTION
## Related issue

Closes #51

## Proposed changes

This patch adds a GDPR compliant consent banner for cookies and Google Analytics:

<img width="1904" alt="Bildschirmfoto 2020-11-06 um 11 37 19" src="https://user-images.githubusercontent.com/3372410/98357364-611b7400-2025-11eb-8a54-e23c8fc82f16.png">

When the user removes "Statistics", Google Analytics **will not be enabled**. Google Analytics is also **not enabled by default** which will imply a significant drop in reported users there.

## Further comments

@jfcurran please style the thing according to ORY Design principles. The relevant styling is in `gdpr.tsx`.

@vinckr @jaredpreston @Bin-fluence please factor this into your reporting (you should add a time marker to Google Analytics indicating when this change was applied).