### PR TITLE
fix: repo URLs in react native blog post

### DIFF
--- a/src/pages/blog/kratos-react-native.mdx
+++ b/src/pages/blog/kratos-react-native.mdx
@@ -64,7 +64,7 @@ as well. Both are maintained by [@aeneasr](https://github.com/aeneasr) and
   <div className="row justify-center-sm">
     <div className="col-sm-6">
       <p>
-        <a href={'https://github.com/ory/kratos'} rel="nofollow noopener">
+        <a href="https://github.com/ory/kratos" rel="nofollow noopener">
           <img
             alt="ORY Kratos GitHub Card"
             src="https://gh-card.dev/repos/ory/kratos.svg?fullname="
@@ -75,7 +75,7 @@ as well. Both are maintained by [@aeneasr](https://github.com/aeneasr) and
     <div className="col-sm-6">
       <p>
         <a
-          href={'https://github.com/ory/kratos-selfservice-ui-react-native'}
+          href="https://github.com/ory/kratos-selfservice-ui-react-native"
           rel="nofollow noopener"
         >
           <img


### PR DESCRIPTION
not sure what happened here, but the URLs didnt get the right quotation marks