### PR TITLE
feat: add new highlights.tsx component

### DIFF
--- a/src/components/highlights.module.css
+++ b/src/components/highlights.module.css
@@ -1,0 +1,77 @@
+@import '../styles/properties.css';
+
+.highlight {
+    background: linear-gradient(
+            to bottom,
+            var(--colors-base-black) 96px,
+            var(--colors-base-light) 96px
+    );
+
+    & h3 {
+        color: var(--colors-themed-default);
+        font-size: 1.2rem;
+        min-height: 3rem;
+    }
+
+    & :global a:any-link {
+        color: var(--colors-base-dark);
+
+        &:hover {
+            color: var(--colors-base-white);
+        }
+    }
+}
+
+.highlight-row {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+}
+
+.highlight-box {
+    width: 30%;
+    background-color: var(--colors-base-white);
+    padding: 32px 16px;
+
+    &:hover {
+        background-color: var(--colors-themed-default);
+        transform: translateY(-4px);
+        transition: 0.25s ease-in-out;
+
+        & h3 {
+            color: var(--colors-base-white);
+        }
+    }
+}
+
+@media (--sm-viewport) {
+    .highlight {
+        & h3 {
+            font-size: 1.067rem;
+        }
+    }
+
+    .highlight-row {
+        flex-wrap: wrap;
+    }
+
+    .highlight-box {
+        width: 100%;
+    }
+}
+
+@media (--md-viewport) {
+    .highlight {
+        & h3 {
+            font-size: 1.125rem;
+        }
+    }
+
+    .highlight-row {
+        flex-wrap: wrap;
+    }
+
+    .highlight-box {
+        width: 100%;
+    }
+}

--- a/src/components/highlights.module.css.d.ts
+++ b/src/components/highlights.module.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly "highlight": string;
+  readonly "highlightRow": string;
+  readonly "highlightBox": string;
+};
+export = styles;

--- a/src/components/highlights.tsx
+++ b/src/components/highlights.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { Link } from 'gatsby'
+import * as styles from './highlights.module.css'
+import cn from 'classnames'
+
+interface PropTypes {
+  highlight: Highlight[]
+}
+
+interface Highlight {
+  title: string
+  content: string
+  href: string
+  openInNewWindow?: boolean
+}
+
+const Highlights = ({ highlight }: PropTypes) => (
+  <div className={cn(styles.highlight)}>
+    <div className="container-fluid">
+      <div className={cn('row middle-lg')}>
+        <div
+          className={cn(
+            'col-lg-offset-1 col-lg-10 col-md-offset-1 col-md-10 col-sm-offset-1 col-sm-10',
+            styles.highlightRow
+          )}
+        >
+          {highlight.map(({ title, content, href, openInNewWindow }) => (
+            <Link
+              key={title}
+              to={href}
+              rel={openInNewWindow ? 'noopener noreferrer' : ''}
+              target={openInNewWindow ? '_blank' : ''}
+              className={cn(styles.highlightBox)}>
+              <div className={cn('col-lg-offset-1 col-lg-10')}>
+                <h3>{title}</h3>
+                <p>{content}</p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  </div>
+)
+
+export default Highlights


### PR DESCRIPTION
- add highlights.tsx component

  - has following proptypes:

```
<Highlights
      highlight={[
      //add `openInNewWindow: true` to make redirects open in new tabs. false by default
     //highlight should render up to 3 elements for aesthetic reasons - no more than three, and no less
        {
          title: '',
          href: '',
          content:
            '',
          openInNewWindow: true,
        },
       {..},
       {..}
   ]} 
/>
```