### PR TITLE
fix: typo in the code example

### DIFF
--- a/src/pages/blog/kratos-react-native.mdx
+++ b/src/pages/blog/kratos-react-native.mdx
@@ -116,7 +116,7 @@ React Native Login, Registration and Profile Management template:
 
 ```shell-session
 $ npm install -g expo-cli
-$ expo init login-signup-app -t @ory/expo-login-registration-template --npm
+$ expo init login-signup-app -t @oryd/expo-login-registration-template --npm
 
 # We also want to install and initialize all required components:
 $ cd login-signup-app


### PR DESCRIPTION
fixed a typo in React Native blogpost code segment that called for ory instead of oryd