### PR TITLE
feat: change proptypes on large-feature.tsx and quicklinks.tsx

### DIFF
--- a/src/components/large-feature.module.css
+++ b/src/components/large-feature.module.css
@@ -12,6 +12,16 @@
     margin-bottom: 16px;
   }
 
+  & :global a:any-link {
+    color: var(--colors-themed-default);
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: var(--colors-base-black);
+    }
+  }
+
   & :global a.cta.primary:any-link {
     color: var(--colors-base-white);
     background-color: var(--colors-themed-default);

--- a/src/components/large-feature.tsx
+++ b/src/components/large-feature.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import cn from 'classnames'
 import * as styles from './large-feature.module.css'
 import Link from '../components/link'
@@ -12,7 +12,7 @@ import Docs from '../images/illustrations/docs.svg'
 
 interface PropTypes {
   title: string
-  description: string
+  description: ReactNode
   learn: string
   href: string
   visual:

--- a/src/components/quicklinks.module.css
+++ b/src/components/quicklinks.module.css
@@ -12,6 +12,16 @@
     margin: 0 0 1rem;
   }
 
+  & :global a:any-link {
+    color: var(--colors-themed-default);
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: var(--colors-base-black);
+    }
+  }
+
   & :global a.cta.secondary:any-link {
     color: var(--colors-base-dark);
     border-color: var(--colors-base-dark);
@@ -57,6 +67,7 @@
   justify-content: space-between;
 
   & .quicklinks-child {
+    min-width: 33%;
     width: auto;
     margin: 0 1rem 0 0;
     padding: 1rem 0;
@@ -76,12 +87,13 @@
     }
 
     & p {
+      font-size: .875rem;
       margin: 0 0 0.5rem;
     }
 
     & .redirects {
       font-weight: 500;
-      font-size: 0.833rem;
+      font-size: 0.875rem;
     }
 
     & img {

--- a/src/components/quicklinks.tsx
+++ b/src/components/quicklinks.tsx
@@ -8,8 +8,6 @@ import Blog from '../images/icon/blog.svg'
 import Jobs from '../images/icon/jobs.svg'
 
 interface PropTypes {
-  title: string
-  description: string
   quick: Quick[]
   cta: CallToAction[]
 }
@@ -45,7 +43,7 @@ const CallToActionButton = ({
   </Link>
 )
 
-const Quicklinks = ({ title, description, quick, cta }: PropTypes) => (
+const Quicklinks = ({ quick, cta }: PropTypes) => (
   <div className={cn(styles.quicklinks)}>
     <div className="container-fluid">
       <div className={cn(styles.quicklinksRow, 'row middle-lg')}>
@@ -55,8 +53,13 @@ const Quicklinks = ({ title, description, quick, cta }: PropTypes) => (
             'col-lg-offset-1 col-lg-3 col-md-offset-1 col-md-10 col-sm-offset-1 col-sm-10'
           )}
         >
-          <h3>{title}</h3>
-          <p>{description}</p>
+          <h3>Ready to get started?</h3>
+          <p>
+            Explore our <Link to={'/products'}>Products</Link> or start building
+            and get authentication, authorization, and user management added to
+            your app. You can also contact us to design a custom package for
+            your business.
+          </p>
           <>{cta.map(CallToActionButton)}</>
         </div>
         <div

--- a/src/pages/developer.tsx
+++ b/src/pages/developer.tsx
@@ -9,6 +9,7 @@ import Stats from '../components/stats'
 import Newsletter from '../components/newsletter'
 import heroIllustration from '../images/illustrations/developer.svg'
 import BlogSummarySection from '../components/blog-summary-section'
+import Link from '../components/link'
 
 const HeroIllustration = () => (
   <img
@@ -75,7 +76,15 @@ const DeveloperPage = () => (
     <LargeFeature
       title={'Resources for success'}
       description={
-        'There is a whole community to help you succeed with an active developer Slack Channel and GitHub Discussions. You can also contact us to create a custom package for your business.'
+        <>
+          There is a whole community to help you succeed with an active
+          developer{' '}
+          <Link to={'https://www.ory.sh/chat'} openInNewWindow={true}>
+            Slack Channel
+          </Link>{' '}
+          and GitHub Discussions. You can also contact us to create a custom
+          package for your business.
+        </>
       }
       learn={'Resources'}
       href={'/resources'}
@@ -100,10 +109,6 @@ const DeveloperPage = () => (
     <Newsletter />
 
     <Quicklinks
-      title={'Ready to get started?'}
-      description={
-        'Explore our Products or start building and get authentication, authorization, and user management added to your app. You can also contact us to design a custom package for your business.'
-      }
       cta={[
         {
           title: 'Start building',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,6 +9,7 @@ import Highlights from '../components/highlights'
 import LargeFeature from '../components/large-feature'
 import Quicklinks from '../components/quicklinks'
 import heroIllustration from '../images/illustrations/hero.svg'
+import Link from '../components/link'
 
 const HeroIllustration = () => (
   <img
@@ -93,7 +94,18 @@ const IndexPage = () => (
       alternate
       title={'Rely on open standards'}
       description={
-        'Give your customers secure choices for how they register and sign in with you. Rely on Oauth 2.0 and OpenID Connect and web standard best practices to secure you and your customers.'
+        <>
+          Give your customers secure choices for how they register and sign in
+          with you. Rely on{' '}
+          <Link to={'https://oauth.net/2/'} openInNewWindow={true}>
+            Oauth 2.0
+          </Link>{' '}
+          and{' '}
+          <Link to={'https://openid.net/connect/'} openInNewWindow={true}>
+            OpenID Connect
+          </Link>{' '}
+          and web standard best practices to secure you and your customers.
+        </>
       }
       learn={'Learn more'}
       href={'/docs/ecosystem/software-architecture-philosophy'}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -141,10 +141,6 @@ const IndexPage = () => (
     <Newsletter />
 
     <Quicklinks
-      title={'Ready to get started?'}
-      description={
-        'Explore our Products or start building and get authentication, authorization, and user management added to your app. You can also contact us to design a custom package for your business.'
-      }
       cta={[
         {
           title: 'Start building',

--- a/src/pages/products.tsx
+++ b/src/pages/products.tsx
@@ -89,10 +89,6 @@ const ProductsPage = () => (
     <Newsletter />
 
     <Quicklinks
-      title={'Ready to get started?'}
-      description={
-        'Explore our Products or start building and get authentication, authorization, and user management added to your app. You can also contact us to design a custom package for your business.'
-      }
       cta={[
         {
           title: 'Start building',

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -77,10 +77,6 @@ const ResourcePage = () => (
     <Newsletter />
 
     <Quicklinks
-      title={'Ready to get started?'}
-      description={
-        'Explore our Products or start building and get authentication, authorization, and user management added to your app. You can also contact us to design a custom package for your business.'
-      }
       cta={[
         {
           title: 'Start building',


### PR DESCRIPTION
- `<a>` Links can now be included within the contents of large-feature.tsx and quicklinks.tsx
- this was done giving large-feature.tsx's `{desciption}` prop the type `ReactNode` 
- parts of quicklinks.tsx's content werde incorporated into the components as they were repeated 1 to 1 for each instance of the component on individual pages