### PR TITLE
fix(docs): cleanup backticks in article

### DIFF
--- a/src/pages/blog/run-oauth2-server-open-source-api-security.md
+++ b/src/pages/blog/run-oauth2-server-open-source-api-security.md
@@ -363,7 +363,6 @@ This command produces an overview of the CLI as follows:
 
 ```shell-session
 Run and manage ORY Hydra
-```
 
 Usage: hydra [command]
 
@@ -379,7 +378,7 @@ unknown certificate authorities
 
 Use "hydra [command] --help" for more information about a command.
 
-````
+```
 
 ## Performing the OAuth2 Client Credentials Flow
 
@@ -395,7 +394,7 @@ $ docker run --rm -it \
     --secret some-secret \
     --grant-types client_credentials \
     --response-types token,code
-````
+```
 
 Now the infrastructure is all set up, and it's time to perform the OAuth2 Client
 Credentials Flow. In this case the CLI will be used to create an OAuth2 Client


### PR DESCRIPTION
## Related issue
None.

## Proposed changes
Fixed the markdown of the [run-oauth2-server-open-source-api-security](https://www.ory.sh/run-oauth2-server-open-source-api-security/) article.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments
Rock'n Roll