### PR TITLE
fix: hero landing page layout

### DIFF
--- a/src/components/layouts/adopters/adopters-content.tsx
+++ b/src/components/layouts/adopters/adopters-content.tsx
@@ -57,7 +57,7 @@ export const adoptersDefault = {
       image: threerein,
       url: 'https://3rein.com/'
     },
-    {      
+    {
       title: 'Contraste Digital',
       image: contraste,
       url: 'https://www.contraste.com/en/digital'

--- a/src/components/layouts/hero/hero.tsx
+++ b/src/components/layouts/hero/hero.tsx
@@ -19,8 +19,8 @@ interface PropTypes {
 
 const Hero = ({ title, description, image, buttons }: PropTypes) => (
   <div className={cn(hero)}>
-    <Container fluid={true} alignItems={'center'}>
-      <Grid lg={4} md={3} sm={12} xs={12} className={cn(pb32)}>
+    <Container fluid={true} alignItems={'center'} >
+      <Grid lg={6} md={7} sm={12} xs={12} className={cn(pb32)}>
         <ContentText>
           <MoleculeTextInteraction>
             <Molecule className={cn(pb48)}>
@@ -31,7 +31,7 @@ const Hero = ({ title, description, image, buttons }: PropTypes) => (
           </MoleculeTextInteraction>
         </ContentText>
       </Grid>
-      <Grid lg={6} md={8} sm={12} xs={12}>
+      <Grid lg={6} md={5} sm={12} xs={12}>
         <ContentVisual>{image}</ContentVisual>
       </Grid>
     </Container>

--- a/src/components/layouts/hero/hero.tsx
+++ b/src/components/layouts/hero/hero.tsx
@@ -19,7 +19,7 @@ interface PropTypes {
 
 const Hero = ({ title, description, image, buttons }: PropTypes) => (
   <div className={cn(hero)}>
-    <Container fluid={true} alignItems={'center'} >
+    <Container fluid={true} alignItems={'center'}>
       <Grid lg={6} md={7} sm={12} xs={12} className={cn(pb32)}>
         <ContentText>
           <MoleculeTextInteraction>


### PR DESCRIPTION
This patch changes the landing page hero to be on one line in all viewports (esp "lg" + "md")
If this patch is accepted I would change it in the same way for /hydra ect.
Let me know what you think.
