### PR TITLE
feat: add security.txt to .well-known

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:security@ory.sh
+Expires: 2022-05-31T22:00:00.000Z
+Preferred-Languages: en,de


### PR DESCRIPTION
We should add more pages around our policies and stuff, but that will be a task for when we setup a bug bounty program.

File created using https://securitytxt.org/