### PR TITLE
chore: update repository template to f62edfea

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,2 @@
+todo:
+  keyword: "@todo"


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/f62edfea9c162e724a286224e34d84cc3bef6807.